### PR TITLE
goci-1710-trait-sync-improvements Rabbit MQ integration for trait upd…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <dependency>
             <groupId>uk.ac.ebi.spot.gwas</groupId>
             <artifactId>gwasdepo-commons</artifactId>
-            <version>1.0.48-SNAPSHOT</version>
+            <version>1.0.49-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/uk/ac/ebi/spot/gwas/curation/config/DiseaseTraitMQConfiguration.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/curation/config/DiseaseTraitMQConfiguration.java
@@ -1,0 +1,35 @@
+package uk.ac.ebi.spot.gwas.curation.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.spot.gwas.deposition.config.DiseaseTraitMQConfigProperties;
+
+@Component
+public class DiseaseTraitMQConfiguration {
+
+    @Autowired
+    DiseaseTraitMQConfigProperties diseaseTraitMQConfigProperties;
+
+    @Bean
+    Queue diseaseTraitQueue() {
+        return new Queue(diseaseTraitMQConfigProperties.getDiseasetraitQueueName());
+    }
+
+    @Bean
+    DirectExchange diseaseTraitExchange() {
+        return new DirectExchange(diseaseTraitMQConfigProperties.getDiseasetraitExchangeName());
+    }
+
+
+    @Bean
+    Binding diseaseTraitBinding(Queue diseaseTraitQueue, DirectExchange diseaseTraitExchange) {
+        return BindingBuilder.bind(diseaseTraitQueue).to(diseaseTraitExchange).with(diseaseTraitMQConfigProperties.getDiseasetraitRoutingKey());
+    }
+
+
+}

--- a/src/main/java/uk/ac/ebi/spot/gwas/curation/config/EFOTraitMQConfiguration.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/curation/config/EFOTraitMQConfiguration.java
@@ -1,0 +1,33 @@
+package uk.ac.ebi.spot.gwas.curation.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.spot.gwas.deposition.config.EFOTraitMQConfigProperties;
+
+@Component
+public class EFOTraitMQConfiguration {
+
+    @Autowired
+    EFOTraitMQConfigProperties efoTraitMQConfigProperties;
+
+    @Bean
+    Queue efoTraitQueue() {
+        return new Queue(efoTraitMQConfigProperties.getEfoTraitQueueName(), true);
+    }
+
+    @Bean
+    DirectExchange efoTraitExchange() {
+        return new DirectExchange(efoTraitMQConfigProperties.getEfoTraitExchangeName());
+    }
+
+    @Bean
+    Binding efoTraitBinding(Queue efoTraitQueue, DirectExchange efoTraitExchange) {
+        return BindingBuilder.bind(efoTraitQueue).to(efoTraitExchange).with(efoTraitMQConfigProperties.getEfoTraitRoutingKey());
+    }
+
+}

--- a/src/main/java/uk/ac/ebi/spot/gwas/curation/config/MetaDataYmlConfiguration.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/curation/config/MetaDataYmlConfiguration.java
@@ -11,9 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.ac.ebi.spot.gwas.deposition.config.RabbitMQConfigProperties;
 import uk.ac.ebi.spot.gwas.deposition.dto.StudyDto;
-import uk.ac.ebi.spot.gwas.deposition.dto.curation.MetadataYmlUpdate;
-import uk.ac.ebi.spot.gwas.deposition.dto.curation.PublicationRabbitMessage;
-import uk.ac.ebi.spot.gwas.deposition.dto.curation.StudyRabbitMessage;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -53,6 +51,8 @@ public class MetaDataYmlConfiguration {
         idClassMapping.put("metadataYmlUpdate", MetadataYmlUpdate.class);
         idClassMapping.put("studyIngest", StudyRabbitMessage.class);
         idClassMapping.put("publicationRabbitMessage", PublicationRabbitMessage.class);
+        idClassMapping.put("efoTraitRabbitMessage", EfoTraitRabbitMessage.class);
+        idClassMapping.put("diseaseTraitRabbitMessage", DiseaseTraitRabbitMessage.class);
         classMapper.setIdClassMapping(idClassMapping);
         classMapper.setDefaultType(Map.class);
         classMapper.setTrustedPackages("*");

--- a/src/main/java/uk/ac/ebi/spot/gwas/curation/rabbitmq/DiseaseTraitMQProducer.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/curation/rabbitmq/DiseaseTraitMQProducer.java
@@ -1,0 +1,29 @@
+package uk.ac.ebi.spot.gwas.curation.rabbitmq;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.spot.gwas.deposition.config.DiseaseTraitMQConfigProperties;
+
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.DiseaseTraitRabbitMessage;
+
+@Slf4j
+@Component
+public class DiseaseTraitMQProducer {
+
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    DiseaseTraitMQConfigProperties diseaseTraitMQConfigProperties;
+
+    public DiseaseTraitMQProducer(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    public void send(DiseaseTraitRabbitMessage diseaseTraitRabbitMessage) {
+        log.info("the meassage for diseaseTrait for Rabbit is {}", diseaseTraitRabbitMessage.getTrait());
+        rabbitTemplate.convertAndSend(diseaseTraitMQConfigProperties.getDiseasetraitExchangeName(),
+                diseaseTraitMQConfigProperties.getDiseasetraitRoutingKey(), diseaseTraitRabbitMessage);
+    }
+}

--- a/src/main/java/uk/ac/ebi/spot/gwas/curation/rabbitmq/EFOTraitMQProducer.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/curation/rabbitmq/EFOTraitMQProducer.java
@@ -1,0 +1,28 @@
+package uk.ac.ebi.spot.gwas.curation.rabbitmq;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.spot.gwas.deposition.config.EFOTraitMQConfigProperties;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.EfoTraitRabbitMessage;
+
+@Slf4j
+@Component
+public class EFOTraitMQProducer {
+
+    private  RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    EFOTraitMQConfigProperties efoTraitMQConfigProperties;
+
+    public EFOTraitMQProducer(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    public void send(EfoTraitRabbitMessage efoTraitRabbitMessage) {
+        log.info("the meassage for EFOtrait for Rabbit is {},{}", efoTraitRabbitMessage.getShortForm(), efoTraitRabbitMessage.getTrait());
+        rabbitTemplate.convertAndSend(efoTraitMQConfigProperties.getEfoTraitExchangeName(),
+                efoTraitMQConfigProperties.getEfoTraitRoutingKey(), efoTraitRabbitMessage);
+    }
+}

--- a/src/main/java/uk/ac/ebi/spot/gwas/curation/rest/dto/DiseaseTraitRabbitMessageAssembler.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/curation/rest/dto/DiseaseTraitRabbitMessageAssembler.java
@@ -1,0 +1,20 @@
+package uk.ac.ebi.spot.gwas.curation.rest.dto;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.spot.gwas.deposition.domain.DiseaseTrait;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.DiseaseTraitRabbitMessage;
+
+@Component
+public class DiseaseTraitRabbitMessageAssembler {
+
+    public DiseaseTraitRabbitMessage assemble(DiseaseTrait diseaseTrait, String operation) {
+        return DiseaseTraitRabbitMessage.builder()
+                .trait(diseaseTrait.getTrait())
+                .mongoSeqId(diseaseTrait.getId())
+                .operation(operation)
+                .build();
+
+    }
+}
+

--- a/src/main/java/uk/ac/ebi/spot/gwas/curation/rest/dto/EFOTraitRabbitMessageAssembler.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/curation/rest/dto/EFOTraitRabbitMessageAssembler.java
@@ -1,0 +1,19 @@
+package uk.ac.ebi.spot.gwas.curation.rest.dto;
+
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.spot.gwas.deposition.domain.EfoTrait;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.EfoTraitRabbitMessage;
+
+@Component
+public class EFOTraitRabbitMessageAssembler {
+
+  public EfoTraitRabbitMessage assemble(EfoTrait efoTrait, String operation) {
+        return EfoTraitRabbitMessage.builder()
+                .trait(efoTrait.getTrait())
+                .shortForm(efoTrait.getShortForm())
+                .uri(efoTrait.getUri())
+                .mongoSeqId(efoTrait.getId())
+                .operation(operation)
+                .build();
+    }
+}

--- a/src/main/java/uk/ac/ebi/spot/gwas/curation/rest/dto/MultiTraitStudyMappingDtoAssembler.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/curation/rest/dto/MultiTraitStudyMappingDtoAssembler.java
@@ -1,0 +1,62 @@
+package uk.ac.ebi.spot.gwas.curation.rest.dto;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.spot.gwas.curation.service.DiseaseTraitService;
+import uk.ac.ebi.spot.gwas.curation.service.EfoTraitService;
+import uk.ac.ebi.spot.gwas.deposition.domain.DiseaseTrait;
+import uk.ac.ebi.spot.gwas.deposition.domain.EfoTrait;
+import uk.ac.ebi.spot.gwas.deposition.domain.Study;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.MultiTraitStudyMappingDto;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+public class MultiTraitStudyMappingDtoAssembler {
+
+    @Autowired
+    EfoTraitService efoTraitService;
+
+    @Autowired
+    DiseaseTraitService diseaseTraitService;
+
+  public  MultiTraitStudyMappingDto assemble(Study study) {
+      String efoShortForms = study.getEfoTraits() != null ?
+              study.getEfoTraits()
+              .stream()
+              .map(efoId -> efoTraitService.getEfoTrait(efoId))
+              .filter(Optional::isPresent)
+              .map(Optional::get)
+              .map(EfoTrait::getShortForm)
+              .collect(Collectors.joining("\\| ")) : "";
+
+      String bgEfoShortForms = study.getBackgroundEfoTraits() != null ?
+              study.getBackgroundEfoTraits()
+                      .stream()
+              .map(efoId -> efoTraitService.getEfoTrait(efoId))
+              .filter(Optional::isPresent)
+              .map(Optional::get)
+              .map(EfoTrait::getShortForm)
+              .collect(Collectors.joining("\\| ")) : "";
+
+      String reportedTrait = Optional.ofNullable(study.getDiseaseTrait())
+              .map(traitId -> diseaseTraitService.getDiseaseTrait(traitId))
+              .filter(Optional::isPresent)
+              .map(Optional::get)
+              .map(DiseaseTrait::getTrait)
+              .orElse("");
+
+
+      return MultiTraitStudyMappingDto.builder()
+              .gcst(study.getAccession())
+              .studyTag(study.getStudyTag())
+              .efoTraitShortForm(efoShortForms)
+              .backgroundEfoShortForm(bgEfoShortForms)
+              .reportedTrait(reportedTrait)
+              .build();
+
+
+  }
+
+}

--- a/src/main/java/uk/ac/ebi/spot/gwas/curation/service/impl/DiseaseTraitServiceImpl.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/curation/service/impl/DiseaseTraitServiceImpl.java
@@ -17,8 +17,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import uk.ac.ebi.spot.gwas.curation.config.RestInteractionConfig;
 import uk.ac.ebi.spot.gwas.curation.constants.DepositionCurationConstants;
+import uk.ac.ebi.spot.gwas.curation.rabbitmq.DiseaseTraitMQProducer;
 import uk.ac.ebi.spot.gwas.curation.repository.DiseaseTraitRepository;
 import uk.ac.ebi.spot.gwas.curation.repository.StudyRepository;
+import uk.ac.ebi.spot.gwas.curation.rest.dto.DiseaseTraitRabbitMessageAssembler;
 import uk.ac.ebi.spot.gwas.curation.service.DiseaseTraitService;
 import uk.ac.ebi.spot.gwas.curation.util.FileHandler;
 import uk.ac.ebi.spot.gwas.deposition.domain.DiseaseTrait;
@@ -59,14 +61,23 @@ public class DiseaseTraitServiceImpl implements DiseaseTraitService {
     @Autowired
     FileHandler fileHandler;
 
+    @Autowired
+    DiseaseTraitMQProducer diseaseTraitMQProducer;
+
+    @Autowired
+    DiseaseTraitRabbitMessageAssembler diseaseTraitRabbitMessageAssembler;
+
     public DiseaseTraitServiceImpl(DiseaseTraitRepository diseaseTraitRepository) {
         this.diseaseTraitRepository = diseaseTraitRepository;
     }
 
     public DiseaseTrait createDiseaseTrait(DiseaseTrait diseaseTrait) {
         Optional<DiseaseTrait> optDiseaseTrait = getDiseaseTraitByTraitName(diseaseTrait.getTrait());
-        if(!optDiseaseTrait.isPresent())
-        return diseaseTraitRepository.insert(diseaseTrait);
+        if(!optDiseaseTrait.isPresent()) {
+            DiseaseTrait insertedDiseaseTrait = diseaseTraitRepository.insert(diseaseTrait);
+            sendMessage(insertedDiseaseTrait, "insert");
+            return insertedDiseaseTrait;
+        }
         else
         throw new CannotCreateTraitWithDuplicateNameException("Trait already exists with name"+optDiseaseTrait.get().getTrait());
     }
@@ -81,7 +92,8 @@ public class DiseaseTraitServiceImpl implements DiseaseTraitService {
                 if(optDiseaseTrait.isPresent())
                     throw new CannotCreateTraitWithDuplicateNameException("Trait already exists with name"+optDiseaseTrait.get().getTrait());
                 diseaseTrait.setCreated(new Provenance(DateTime.now(), user.getId()));
-                diseaseTraitRepository.insert(diseaseTrait);
+                DiseaseTrait insertedDiseaseTrait =  diseaseTraitRepository.insert(diseaseTrait);
+                sendMessage(insertedDiseaseTrait, "insert");
                 report.add(new TraitUploadReport(diseaseTrait.getTrait(),"Trait successfully Inserted : "+diseaseTrait.getTrait(),null));
             } catch(DataAccessException | CannotCreateTraitWithDuplicateNameException ex) {
                 uploadReportWrapper.setHasErrors(true);
@@ -96,6 +108,7 @@ public class DiseaseTraitServiceImpl implements DiseaseTraitService {
     public DiseaseTrait updateDiseaseTrait(DiseaseTrait diseaseTrait) {
         log.info("Inside updateDiseaseTrait()");
         DiseaseTrait diseaseTraitUpdated = diseaseTraitRepository.save(diseaseTrait);
+        sendMessage(diseaseTraitUpdated, "update");
         return diseaseTraitUpdated;
     }
 
@@ -110,8 +123,10 @@ public class DiseaseTraitServiceImpl implements DiseaseTraitService {
                 if(!checkForLinkedStudies(traitId)) {
                     String traitname = "";
                     Optional<DiseaseTrait> diseaseTraitOptional = getDiseaseTrait(traitId);
-                    if(diseaseTraitOptional.isPresent())
+                    if(diseaseTraitOptional.isPresent()) {
                         traitname = getDiseaseTrait(traitId).get().getTrait();
+                        sendMessage(diseaseTraitOptional.get(), "delete");
+                    }
                     diseaseTraitRepository.deleteById(traitId);
                 }
                 else
@@ -158,7 +173,9 @@ public class DiseaseTraitServiceImpl implements DiseaseTraitService {
             Optional.ofNullable(diseaseTraitDto.getTrait()).ifPresent(trait -> diseaseTrait.setTrait(diseaseTraitDto.getTrait()));
 
             diseaseTrait.setUpdated(new Provenance(DateTime.now(), user.getId()));
-            return diseaseTraitRepository.save(diseaseTrait);
+            DiseaseTrait updatedDiseaseTrait = diseaseTraitRepository.save(diseaseTrait);
+            sendMessage(updatedDiseaseTrait, "update");
+            return updatedDiseaseTrait;
         } else {
             throw new EntityNotFoundException("Disease Trait Not found");
         }
@@ -216,4 +233,8 @@ public class DiseaseTraitServiceImpl implements DiseaseTraitService {
 
     }
 
+
+    private void sendMessage(DiseaseTrait diseaseTrait, String operation) {
+        diseaseTraitMQProducer.send(diseaseTraitRabbitMessageAssembler.assemble(diseaseTrait, operation));
+    }
 }

--- a/src/main/java/uk/ac/ebi/spot/gwas/curation/service/impl/EfoTraitServiceImpl.java
+++ b/src/main/java/uk/ac/ebi/spot/gwas/curation/service/impl/EfoTraitServiceImpl.java
@@ -6,8 +6,10 @@ import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import uk.ac.ebi.spot.gwas.curation.rabbitmq.EFOTraitMQProducer;
 import uk.ac.ebi.spot.gwas.curation.repository.EfoTraitRepository;
 import uk.ac.ebi.spot.gwas.curation.repository.StudyRepository;
+import uk.ac.ebi.spot.gwas.curation.rest.dto.EFOTraitRabbitMessageAssembler;
 import uk.ac.ebi.spot.gwas.curation.rest.dto.EfoTraitDtoAssembler;
 import uk.ac.ebi.spot.gwas.curation.service.EfoTraitService;
 import uk.ac.ebi.spot.gwas.curation.util.CurationUtil;
@@ -38,11 +40,19 @@ public class EfoTraitServiceImpl implements EfoTraitService {
 
     private final FileHandler fileHandler;
 
-    public EfoTraitServiceImpl(EfoTraitRepository efoTraitRepository, StudyRepository studyRepository, EfoTraitDtoAssembler efoTraitDtoAssembler, FileHandler fileHandler) {
+    EFOTraitMQProducer efoTraitMQProducer;
+
+    EFOTraitRabbitMessageAssembler efoTraitRabbitMessageAssembler;
+
+    public EfoTraitServiceImpl(EfoTraitRepository efoTraitRepository, StudyRepository studyRepository, EfoTraitDtoAssembler efoTraitDtoAssembler, FileHandler fileHandler,
+                               EFOTraitMQProducer efoTraitMQProducer,
+                               EFOTraitRabbitMessageAssembler efoTraitRabbitMessageAssembler) {
         this.efoTraitRepository = efoTraitRepository;
         this.studyRepository = studyRepository;
         this.efoTraitDtoAssembler = efoTraitDtoAssembler;
         this.fileHandler = fileHandler;
+        this.efoTraitMQProducer = efoTraitMQProducer;
+        this.efoTraitRabbitMessageAssembler = efoTraitRabbitMessageAssembler;
     }
 
     @Override
@@ -55,6 +65,7 @@ public class EfoTraitServiceImpl implements EfoTraitService {
                 String uri = efoTrait.getUri();
                 efoTrait.setShortForm(uri.substring(uri.lastIndexOf('/') + 1));
                 efoTraitCreated = efoTraitRepository.insert(efoTrait);
+                sendMessageToQueue(efoTrait, "insert");
             }
         }
         catch (DuplicateKeyException e) {
@@ -138,7 +149,9 @@ public class EfoTraitServiceImpl implements EfoTraitService {
             updatedEfoTrait.setUpdated(new Provenance(DateTime.now(), user.getId()));
             try {
 
-                return efoTraitRepository.save(updatedEfoTrait);
+                EfoTrait savedEfoTrait = efoTraitRepository.save(updatedEfoTrait);
+                sendMessageToQueue(savedEfoTrait,"update");
+                return savedEfoTrait;
             }
             catch (DuplicateKeyException e) {
                 throw new CannotCreateTraitWithDuplicateUriException("Trait with same URI already exists.");
@@ -230,7 +243,10 @@ public class EfoTraitServiceImpl implements EfoTraitService {
                 assignedToStudyTraits.add(traitId);
             }
             else {
+                EfoTrait deletedTrait = efoTraitRepository.findById(traitId).orElse(null);
+                sendMessageToQueue(deletedTrait, "delete");
                 efoTraitRepository.deleteById(traitId);
+
             }
         }
         if (!notFoundTraits.isEmpty()) {
@@ -240,4 +256,10 @@ public class EfoTraitServiceImpl implements EfoTraitService {
             throw new CannotDeleteTraitException("Unable to delete EFO trait " + assignedToStudyTraits + " as they are linked to studies.");
         }
     }
+
+    private void sendMessageToQueue(EfoTrait efoTrait, String operation) {
+
+        efoTraitMQProducer.send(efoTraitRabbitMessageAssembler.assemble(efoTrait, operation));
+    }
+
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -117,3 +117,12 @@ rabbitmq:
     queue-name: publication-sandbox
     exchange-name: publication-exchange-sandbox
     routing-key: publication-route-sandbox
+  efotrait:
+    queue-name: efotrait-sandbox
+    exchange-name: efotrait-exchange-sandbox
+    routing-key: efotrait-route-sandbox
+  diseasetrait:
+    queue-name: diseasetrait-sandbox
+    exchange-name: diseasetrait-exchange-sandbox
+    routing-key: diseasetrait-route-sandbox
+

--- a/src/main/resources/application-prod-fallback.yml
+++ b/src/main/resources/application-prod-fallback.yml
@@ -85,6 +85,14 @@ rabbitmq:
     queue-name: publication
     exchange-name: publication-exchange
     routing-key: publication-route
+  efotrait:
+    queue-name: efotrait
+    exchange-name: efotrait-exchange
+    routing-key: efotrait-route
+  diseasetrait:
+    queue-name: diseasetrait
+    exchange-name: diseasetrait-exchange
+    routing-key: diseasetrait-route
 
 ftp:
   link:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -85,6 +85,14 @@ rabbitmq:
     queue-name: publication
     exchange-name: publication-exchange
     routing-key: publication-route
+  efotrait:
+    queue-name: efotrait
+    exchange-name: efotrait-exchange
+    routing-key: efotrait-route
+  diseasetrait:
+    queue-name: diseasetrait
+    exchange-name: diseasetrait-exchange
+    routing-key: diseasetrait-route
 
 ftp:
   link:

--- a/src/main/resources/application-sandbox-migration.yml
+++ b/src/main/resources/application-sandbox-migration.yml
@@ -122,3 +122,11 @@ rabbitmq:
     queue-name: publication-sandbox
     exchange-name: publication-exchange-sandbox
     routing-key: publication-route-sandbox
+  efotrait:
+    queue-name: efotrait-sandbox
+    exchange-name: efotrait-exchange-sandbox
+    routing-key: efotrait-route-sandbox
+  diseasetrait:
+    queue-name: diseasetrait-sandbox
+    exchange-name: diseasetrait-exchange-sandbox
+    routing-key: diseasetrait-route-sandbox

--- a/src/test/java/uk/ac/ebi/spot/gwas/curation/config/EfoTraitConfiguration.java
+++ b/src/test/java/uk/ac/ebi/spot/gwas/curation/config/EfoTraitConfiguration.java
@@ -3,8 +3,10 @@ package uk.ac.ebi.spot.gwas.curation.config;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
+import uk.ac.ebi.spot.gwas.curation.rabbitmq.EFOTraitMQProducer;
 import uk.ac.ebi.spot.gwas.curation.repository.EfoTraitRepository;
 import uk.ac.ebi.spot.gwas.curation.repository.StudyRepository;
+import uk.ac.ebi.spot.gwas.curation.rest.dto.EFOTraitRabbitMessageAssembler;
 import uk.ac.ebi.spot.gwas.curation.rest.dto.EfoTraitDtoAssembler;
 import uk.ac.ebi.spot.gwas.curation.rest.dto.ProvenanceDtoAssembler;
 import uk.ac.ebi.spot.gwas.curation.service.EfoTraitService;
@@ -40,8 +42,12 @@ public class EfoTraitConfiguration {
     @MockBean
     ProvenanceDtoAssembler provenanceDtoAssembler;
 
+    EFOTraitMQProducer efoTraitMQProducer;
+
+    EFOTraitRabbitMessageAssembler efoTraitRabbitMessageAssembler;
+
     @Bean
     public EfoTraitService efoTraitService() {
-        return new EfoTraitServiceImpl(efoTraitRepository, studyRepository, efoTraitDtoAssembler, fileHandler);
+        return new EfoTraitServiceImpl(efoTraitRepository, studyRepository, efoTraitDtoAssembler, fileHandler, efoTraitMQProducer, efoTraitRabbitMessageAssembler);
     }
 }


### PR DESCRIPTION
The PR is linked to the below tickets
https://github.com/EBISPOT/goci/issues/1710
https://github.com/EBISPOT/goci/issues/1709

The changes includes creating a message queue for handling messages for EFO Trait & Reported Trait changes . Existing rabbitmq queues are used , the consumer is running at codon cluster & listens to incoming messages & updates oracle at near real time basis, An email will be sent to curators in case the message consuming fails

Also code changes are done to download pre-populated multi trait study mapping file , a new endpoint has been created for the same